### PR TITLE
Update to avoid deprecations of React 0.12.0, add examples, update docs and related

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,13 @@
+# http://editorconfig.org
+root = true
+
+[*]
+indent_style = space
+indent_size = 2
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.md]
+trim_trailing_whitespace = false

--- a/.jshintrc
+++ b/.jshintrc
@@ -1,0 +1,37 @@
+{
+  "predef": [
+    "define",
+    "module",
+    "require"
+  ],
+
+  "asi" : false,
+  "bitwise": true,
+  "boss": false,
+  "browser": true,
+  "curly" : true,
+  "debug": false,
+  "devel": false,
+  "eqeqeq": true,
+  "evil": false,
+  "expr": true,
+  "forin": false,
+  "immed": true,
+  "jquery" : false,
+  "latedef" : false,
+  "laxbreak": true,
+  "laxcomma": true,
+  "multistr": true,
+  "newcap": true,
+  "noarg": true,
+  "noempty": false,
+  "onevar": false,
+  "plusplus": false,
+  "quotmark": "double",
+  "regexp": false,
+  "strict": false,
+  "sub": false,
+  "trailing" : true,
+  "undef": true,
+  "unused": "vars"
+}

--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,1 @@
+example

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,12 @@
+### 0.1.3 (2015-01-07)
+
+* Remove deprecation warnings `"Warning: Something is calling a React component directly. Use a factory or JSX instead"`
+* Get rid of deprecated `transferPropsTo`
+* Update CSS styles
+* Add examples
+
+### 0.1.1 (2014-10-16)
+
+* `validate` prop which is a function that returns true if a tag is valid.
+* Add tag when input is blurred.
+* `addKeys` prop which defines key code that add a tag, default is Tab (9) and Enter (13.)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,13 @@
-### 0.1.3 (2015-01-07)
+### 0.2.0 (2015-01-07)
 
-* Remove deprecation warnings `"Warning: Something is calling a React component directly. Use a factory or JSX instead"`
+* Add [UMD](https://github.com/umdjs/umd) support
+* Get rid of warnings `"Something is calling a React component directly. Use a factory or JSX instead"`
 * Get rid of deprecated `transferPropsTo`
 * Update CSS styles
-* Add examples
+* Add usage example
 
 ### 0.1.1 (2014-10-16)
 
 * `validate` prop which is a function that returns true if a tag is valid.
 * Add tag when input is blurred.
-* `addKeys` prop which defines key code that add a tag, default is Tab (9) and Enter (13.)
+* `addKeys` prop which defines key code that add a tag, default is Tab (9) and Enter (13)

--- a/README.md
+++ b/README.md
@@ -21,14 +21,14 @@ bower install react-tagsinput --save
 ## Example
 
 ```js
-var TagsInput = require("./react-tagsinput");
+var TagsInput = require('./react-tagsinput');
 
 var App = React.createClass({
   saveTags: function () {
-    console.log("tags: ", this.refs.tags.getTags().join(", "));
-  }
+    console.log('tags: ', this.refs.tags.getTags().join(', '));
+  }, 
 
-  , render: function () {
+  render: function () {
     return (
       <div>
         <TagsInput ref="tags" tags={["tag1", "tag2"]} />
@@ -80,10 +80,6 @@ Returns an array of the current tags.
 
 Look at `react-tagsinput.css` for an idea on how to style this component.
 
-## CHANGELOG
+## [Changelog]()
 
-### 2014-10-16
 
-* `validate` prop which is a function that returns true if a tag is valid.
-* Add tag when input is blurred.
-* `addKeys` prop which defines key code that add a tag, default is Tab (9) and Enter (13.)

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 > Simple [React](http://facebook.github.io/react/index.html) component for inputing tags.
 
-<img src="https://dl.dropboxusercontent.com/u/100463011/react-tagsinput-demo.gif" width="500">
+<img src="https://dl.dropboxusercontent.com/u/100463011/react-tagsinput-demo.gif" width="400">
 
 ## Demo
 

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ true for every string but the empty string.
 
 ##### addKeys
 
-An array of key codes that add a tag, default is `[9, 13]` (Tab and Enter.)
+An array of key codes that add a tag, default is `[9, 13]` (Tab and Enter).
 
 ##### onChange
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 > Simple [React](http://facebook.github.io/react/index.html) component for inputing tags.
 
+<img src="https://dl.dropboxusercontent.com/u/100463011/react-tagsinput-demo.gif" width="300">
+
 ## Demo
 
 A demonstration can be found here: https://olahol.github.io/react-tagsinput

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 > Simple [React](http://facebook.github.io/react/index.html) component for inputing tags.
 
-<img src="https://dl.dropboxusercontent.com/u/100463011/react-tagsinput-demo.gif" width="300">
+<img src="https://dl.dropboxusercontent.com/u/100463011/react-tagsinput-demo.gif" width="500">
 
 ## Demo
 

--- a/README.md
+++ b/README.md
@@ -2,11 +2,10 @@
 
 > Simple [React](http://facebook.github.io/react/index.html) component for inputing tags.
 
-<img src="https://dl.dropboxusercontent.com/u/100463011/react-tagsinput-demo.gif" width="400">
+### [Demo](https://olahol.github.io/react-tagsinput)
 
-## Demo
+<img src="https://dl.dropboxusercontent.com/u/100463011/react-tagsinput-demo.gif" width="350">
 
-A demonstration can be found here: https://olahol.github.io/react-tagsinput
 
 ## Install
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # react-tagsinput
 
-> Simple react component for inputing tags.
+> Simple [React](http://facebook.github.io/react/index.html) component for inputing tags.
 
 ## Demo
 
@@ -20,7 +20,7 @@ bower install react-tagsinput --save
 
 ## Example
 
-```js
+```javascript
 var TagsInput = require('./react-tagsinput');
 
 var App = React.createClass({
@@ -39,47 +39,51 @@ var App = React.createClass({
 });
 ```
 
-## Props
+## API
 
-### tags
+### Props
+
+##### tags
 
 Tags to preloaded, default is `[]`.
 
-### placeholder
+##### placeholder
 
 Placeholder text for the add a tag input, default is "Add a tag".
 
-### validate
+##### validate
 
 A function which returns true if a tag is valid, default function returns
 true for every string but the empty string.
 
-### addKeys
+##### addKeys
 
 An array of key codes that add a tag, default is `[9, 13]` (Tab and Enter.)
 
-### onChange
+##### onChange
 
 Callback when the tag input changes, the argument is an array of the current tags.
 
-### onTagAdd
+##### onTagAdd
 
 Callback when a tag is added, argument is the added tag.
 
-### onTagRemove
+##### onTagRemove
 
 Callback when a tag is removed, argument is the removed tag.
 
-## Methods
+### Methods
 
-### getTags()
+##### getTags()
 
 Returns an array of the current tags.
 
-## Styling
+## Styles
 
 Look at `react-tagsinput.css` for an idea on how to style this component.
 
-## [Changelog]()
+---
+
+MIT Licensed
 
 

--- a/bower.json
+++ b/bower.json
@@ -23,7 +23,8 @@
     "node_modules",
     "bower_components",
     "test",
-    "tests"
+    "tests",
+    "example"
   ],
   "dependencies": {
     "react": "~0.12.2"

--- a/bower.json
+++ b/bower.json
@@ -4,7 +4,7 @@
     "react-tagsinput.js",
     "react-tagsinput.css"
   ],
-  "version": "0.2.0",
+  "version": "0.2.1",
   "homepage": "https://github.com/olahol/react-tagsinput",
   "description": "Simple react.js component for inputing tags",
   "keywords": [
@@ -15,7 +15,8 @@
     "javascript"
   ],
   "authors": [
-    "Ola Holmström"
+    "Ola Holmström",
+    "Dmitri Voronianski <dmitri.voronianski@gmail.com>"
   ],
   "license": "MIT",
   "ignore": [

--- a/bower.json
+++ b/bower.json
@@ -4,7 +4,7 @@
     "react-tagsinput.js",
     "react-tagsinput.css"
   ],
-  "version": "0.1.2",
+  "version": "0.2.0",
   "homepage": "https://github.com/olahol/react-tagsinput",
   "description": "Simple react.js component for inputing tags",
   "keywords": [

--- a/example/index.html
+++ b/example/index.html
@@ -1,0 +1,62 @@
+<!doctype html>
+<html>
+<head>
+  <title>react-tagsinput example (without JSX)</title>
+  <link rel="stylesheet" href="../react-tagsinput.css">
+  <style>
+    * {
+      margin: 0;
+      padding: 0;
+      border: 0;
+      -moz-box-sizing: border-box;
+      box-sizing: border-box;
+    }
+    body {
+      background: #eeefef;
+    }
+    #tags {
+      width: 80%;
+      margin: 100px auto;
+    }
+    button {
+      background: #e74c3c;
+      color: #fff;
+      border: 1px solid #c0392b;
+      width: 70px;
+      height: 30px;
+      border-radius: 2px;
+      font-size: 12px;
+      font-weight: bold;
+      float: right;
+      margin-top: 10px;
+      line-height: 30px;
+      cursor: pointer;
+      outline: none;
+    }
+  </style>
+</head>
+<body>
+  <div id="tags"></div>
+
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/react/0.12.2/react.min.js"></script>
+  <script src="../react-tagsinput.js"></script>
+  <script>
+    var TagsComponent = React.createClass({
+      displayName: 'TagsComponent',
+      saveTags: function () {
+        console.log('tags: ', this.refs.tags.getTags().join(', '));
+      },
+
+      render: function () {
+        return (
+          React.createElement('div', null,
+            React.createElement(ReactTagsInput, {ref: 'tags', tags: ['tag1', 'tag2']}),
+            React.createElement('button', {onClick: this.saveTags}, 'Save')
+          )
+        );
+      }
+    });
+    React.render(React.createElement(TagsComponent, null), document.getElementById('tags'));
+  </script>
+</body>
+</html>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-tagsinput",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Simple react.js component for inputing tags",
   "main": "react-tagsinput.js",
   "dependencies": {
@@ -22,6 +22,9 @@
     "javascript"
   ],
   "author": "Ola Holmström",
+  "contributors": [
+    "Dmitri Voronianski <dmitri.voronianski@gmail.com>"
+  ],
   "license": "MIT",
   "bugs": {
     "url": "https://github.com/olahol/react-tagsinput/issues"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-tagsinput",
-  "version": "0.1.2",
+  "version": "0.2.0",
   "description": "Simple react.js component for inputing tags",
   "main": "react-tagsinput.js",
   "dependencies": {

--- a/react-tagsinput.css
+++ b/react-tagsinput.css
@@ -1,54 +1,51 @@
 .react-tagsinput {
-	border:1px solid #e8e8e8;
-	background: #FFF;
-	padding:5px;
-	overflow-y: auto;
+  border: 1px solid #ccc;
+  background: #fff;
+  padding: 10px;
+  overflow-y: auto;
+  border-radius: 3px;
 }
 
 .react-tagsinput-tag {
-	-moz-border-radius:2px;
-	-webkit-border-radius:2px;
-	display: block;
-	float: left;
-	padding: 5px;
-	text-decoration:none;
-	background: #8cc63f;
-	color: #fff;
-	margin-right: 5px;
-	margin-bottom:5px;
-	font-family: helvetica;
-	font-size:13px;
+  display: block;
+  border: 1px solid #a5d24a;
+  background: #cde69c;
+  color: #638421;
+  font-size: 12px;
+  font-family: 'Helvetica Neue', 'Arial', sans-serif;
+  float: left;
+  padding: 5px;
+  margin-right: 5px;
+  margin-bottom: 5px;
+  text-decoration: none;
+  border-radius: 2px;
 }
 
 .react-tagsinput-invalid {
-	background: #FBD8DB !important;
-	color: #90111A !important;
+  background: #FBD8DB !important;
+  color: #90111A !important;
 }
 
 .react-tagsinput-remove {
-	font-weight: bold;
-	color: #fff;
-	text-decoration:none;
-	font-size: 11px;
+  font-weight: bold;
+  color: #638421;
+  text-decoration: none;
+  font-size: 11px;
   cursor: pointer;
 }
 
-.react-tagsinput-remove {
-  content: "X";
+.react-tagsinput-remove:before {
+  content: "x";
 }
 
 .react-tagsinput-input {
-	width:80px;
-	margin:0px;
-	font-family: helvetica;
-	font-size: 13px;
-	border:1px solid transparent;
-	padding:5px; background: transparent;
-	color: #777 !important;
-	outline:0px;
-	margin-right:5px;
-	margin-bottom:5px;
-	background-color: #eaf5dc;
-	-moz-border-radius:2px;
-	-webkit-border-radius:2px;
+  background: transparent;
+  color: #777;
+  border: 0;
+  font-size: 13px;
+  font-family: 'Helvetica Neue', 'Arial', sans-serif;
+  padding: 5px;
+  margin: 0;
+  width: 80px;
+  outline: none;
 }

--- a/react-tagsinput.js
+++ b/react-tagsinput.js
@@ -1,4 +1,14 @@
-;(function () {
+;(function (root, factory) {
+    if (typeof module !== "undefined" && module.exports) {
+        module.exports = factory(require("react"));
+    } else if (typeof define === "function" && define.amd) {
+        define(["react"], factory);
+    } else {
+        root.ReactTagsInput = factory(root.React);
+    }
+})(this, function (React) {
+  "use strict";
+
   var Input = React.createClass({
     render: function () {
       var inputClass = this.props.invalid ?
@@ -125,7 +135,7 @@
 
     , render: function() {
       var tagNodes = this.state.tags.map(function (tag, i) {
-        return Tag({
+        return React.createElement(Tag, {
           key: i
           , tag: tag
           , remove: this.removeTag.bind(null, i)
@@ -135,7 +145,7 @@
       return (
         React.DOM.div({
           className: "react-tagsinput"
-        }, tagNodes, Input({
+        }, tagNodes, React.createElement(Input, {
           ref: "input"
           , placeholder: this.props.placeholder
           , value: this.state.tag
@@ -148,9 +158,5 @@
     }
   });
 
-  if (typeof module === "object" && module.exports){
-    module.exports = TagsInput;
-  } else {
-    this.ReactTagsInput = TagsInput;
-  }
-}.call(this));
+  return TagsInput;
+});

--- a/react-tagsinput.js
+++ b/react-tagsinput.js
@@ -15,7 +15,7 @@
         "react-tagsinput-input react-tagsinput-invalid" :
         "react-tagsinput-input";
 
-      return React.DOM.input(
+      return React.createElement("input",
         // https://gist.github.com/sebmarkbage/a6e220b7097eb3c79ab7
         // avoid dependency on ES6's `Object.assign()`
         React.__spread({}, this.props, {
@@ -30,9 +30,9 @@
   var Tag = React.createClass({
     render: function () {
       return (
-        React.DOM.span({
+        React.createElement("span", {
           className: "react-tagsinput-tag"
-        }, this.props.tag + " ", React.DOM.a({
+        }, this.props.tag + " ", React.createElement("a", {
           onClick: this.props.remove
           , className: "react-tagsinput-remove"
         }))
@@ -145,7 +145,7 @@
       }.bind(this));
 
       return (
-        React.DOM.div({
+        React.createElement("div", {
           className: "react-tagsinput"
         }, tagNodes, React.createElement(Input, {
           ref: "input"

--- a/react-tagsinput.js
+++ b/react-tagsinput.js
@@ -15,11 +15,13 @@
         "react-tagsinput-input react-tagsinput-invalid" :
         "react-tagsinput-input";
 
-      return this.transferPropsTo(
-        React.DOM.input({
+      return React.DOM.input(
+        // https://gist.github.com/sebmarkbage/a6e220b7097eb3c79ab7
+        // avoid dependency on ES6's `Object.assign()`
+        React.__spread({}, this.props, {
           type: "text"
-          , className: inputClass
-          , placeholder: this.props.placeholder
+        , className: inputClass
+        , placeholder: this.props.placeholder
         })
       );
     }


### PR DESCRIPTION
* Add [UMD](https://github.com/umdjs/umd) support
* Get rid of warnings `"Something is calling a React component directly. Use a factory or JSX instead"`
* Get rid of deprecated `transferPropsTo`
* Update CSS styles
* Add usage example