### PR TITLE
add tag to be present in http://react-components.com/

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -4,7 +4,7 @@
     "react-tagsinput.js",
     "react-tagsinput.css"
   ],
-  "version": "0.2.1",
+  "version": "0.2.2",
   "homepage": "https://github.com/olahol/react-tagsinput",
   "description": "Simple react.js component for inputing tags",
   "keywords": [
@@ -12,7 +12,8 @@
     "tags",
     "input",
     "component",
-    "javascript"
+    "javascript",
+    "react-component"
   ],
   "authors": [
     "Ola Holmström",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-tagsinput",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "Simple react.js component for inputing tags",
   "main": "react-tagsinput.js",
   "dependencies": {
@@ -19,7 +19,8 @@
     "tags",
     "input",
     "component",
-    "javascript"
+    "javascript",
+    "react-component"
   ],
   "author": "Ola Holmström",
   "contributors": [


### PR DESCRIPTION
Please merge this and republish plugin to NPM (`npm publish .`) and Bower (`git tag 0.2.2` and then `git push --tags`).

See - http://react-components.com/