### PR TITLE
Bug fix: passing empty array to the value prop

### DIFF
--- a/react-tagsinput.js
+++ b/react-tagsinput.js
@@ -96,7 +96,7 @@
 
     , isUncontrolled: function (props) {
       props = props || this.props;
-      return !props.value && !props.valueLink;
+      return !props.value.length && !props.valueLink;
     }
 
     , getValueLink: function () {

--- a/react-tagsinput.js
+++ b/react-tagsinput.js
@@ -96,7 +96,7 @@
 
     , isUncontrolled: function (props) {
       props = props || this.props;
-      return !props.value.length && !props.valueLink;
+      return !(props.value || []).length && !props.valueLink;
     }
 
     , getValueLink: function () {


### PR DESCRIPTION
Example:

    <TagsInput value={[]} />

In this case, I want the component to be controlled, I just want to start with an empty list.