### PR TITLE
CSS height correction + onClick attached to handler

### DIFF
--- a/react-tagsinput.css
+++ b/react-tagsinput.css
@@ -4,7 +4,7 @@
   padding: 4px;
   overflow-y: auto;
   border-radius: 3px;
-  height: 31px;
+  height: 28px;
 }
 
 .react-tagsinput-tag {

--- a/react-tagsinput.js
+++ b/react-tagsinput.js
@@ -255,6 +255,7 @@
       return (
         React.createElement("div", {
           className: ns + "tagsinput"
+          , onClick: this.focus
         }, tagNodes, React.createElement(Input, {
           ref: "input"
           , ns: ns


### PR DESCRIPTION
d2d73ae probably requires no further elaboration. I had some styles from my own environment that were influencing dimensions. This commit corrects the dimensions for your examples in isolation.

c04de20 is more controversial. I've found that the UX of not being able to get focus on the input when clicking anywhere in the box, instead having to guess at the position of the small, moving input, to be suboptimal. This commit calls the `focus()` hook when clicking on the `<div>` wrapper so that no matter where you click, focus goes to the input. I don't know if this is better for all, but definitely better UX from our perspective.