### PR TITLE
Allow users to set their own classes for elements

### DIFF
--- a/react-tagsinput.js
+++ b/react-tagsinput.js
@@ -17,11 +17,13 @@
       var inputClass = this.props.inputClass || ns + "tagsinput-input";
 
       if (this.props.validating) {
-        inputClass += " " + ns + "tagsinput-validating";
+        var validatingClass = this.props.validatingClass || ns + "tagsinput-validating";
+        inputClass += " " + validatingClass;
       }
 
       if (this.props.invalid) {
-        inputClass += " " + ns + "tagsinput-invalid";
+        var invalidClass = this.props.invalidClass || ns + "tagsinput-invalid";
+        inputClass += " " + invalidClass;
       }
 
       return React.createElement("input",
@@ -308,6 +310,8 @@
           , value: this.state.tag
           , invalid: this.state.invalid
           , validating: this.state.validating
+          , invalidClass: this.props.invalidClass
+          , validatingClass: this.props.validatingClass
           , onKeyDown: this.onKeyDown
           , onKeyUp: this.props.onKeyUp
           , onChange: this.onChange

--- a/react-tagsinput.js
+++ b/react-tagsinput.js
@@ -14,7 +14,7 @@
     render: function () {
       var ns = this.props.ns;
 
-      var inputClass = ns + "tagsinput-input";
+      var inputClass = this.props.inputClass || ns + "tagsinput-input";
 
       if (this.props.validating) {
         inputClass += " " + ns + "tagsinput-validating";
@@ -40,10 +40,10 @@
     render: function () {
       return (
         React.createElement("span", {
-          className: this.props.ns + "tagsinput-tag"
+          className: this.props.tagClass || this.props.ns + "tagsinput-tag"
         }, this.props.tag, React.createElement("a", {
           onClick: this.props.remove
-          , className: this.props.ns + "tagsinput-remove"
+          , className: this.props.tagRemoveClass || this.props.ns + "tagsinput-remove"
         }))
       );
     }
@@ -290,6 +290,8 @@
           key: i
           , ns: ns
           , tag: tag
+          , tagClass: this.props.tagClass
+          , tagRemoveClass: this.props.tagRemoveClass
           , remove: this.removeTag.bind(null, tag)
         });
       }.bind(this));
@@ -301,6 +303,7 @@
         }, tagNodes, React.createElement(Input, {
           ref: "input"
           , ns: ns
+          , inputClass: this.props.inputClass
           , placeholder: this.props.placeholder
           , value: this.state.tag
           , invalid: this.state.invalid


### PR DESCRIPTION
This change allows users of the `react-tagsinput` component to set the
CSS classes of the sub-elements of the component themselves.

It's very useful when you already have a stylesheet in place or if you
need to adhere to a naming scheme for your classes (like SuitCSS).