### PR TITLE
Allow preventing form submission

### DIFF
--- a/react-tagsinput.js
+++ b/react-tagsinput.js
@@ -77,6 +77,7 @@
       , validate: React.PropTypes.func
       , validateAsync: React.PropTypes.func
       , renderTag: React.PropTypes.func
+      , required: React.PropTypes.bool
     }
 
     , getDefaultProps: function () {
@@ -100,6 +101,7 @@
         , beforeTagRemove: function () { return true; }
         , transform: function (tag) { return tag.trim(); }
         , renderTag: null
+        , required: false
       };
     }
 
@@ -331,6 +333,7 @@
           , onKeyUp: this.props.onKeyUp
           , onChange: this.onChange
           , onBlur: this.onBlur
+          , required: this.props.required
         }))
       );
     }

--- a/react-tagsinput.js
+++ b/react-tagsinput.js
@@ -316,6 +316,9 @@
         });
       }.bind(this));
 
+      var hasTags = tagNodes.length;
+      var needsTags = this.props.required && !hasTags;
+
       return (
         React.createElement("div", {
           style: this.props.style,
@@ -333,7 +336,7 @@
           , onKeyUp: this.props.onKeyUp
           , onChange: this.onChange
           , onBlur: this.onBlur
-          , required: this.props.required
+          , required: needsTags
         }))
       );
     }

--- a/test/index.js
+++ b/test/index.js
@@ -427,6 +427,18 @@ describe("TagsInput", function () {
       assert.equal(tags[0].getDOMNode().textContent, tag2)
     });
 
+    it("should support required", function() {
+      var tagsinput = createTagsInput({required: true}).tagsInput();
+      var tag = randomString();
+
+      var input = TestUtils.findRenderedDOMComponentWithTag(tagsinput, "input");
+      assert(input.props.required);
+
+      addTag(tagsinput, tag);
+      input = TestUtils.findRenderedDOMComponentWithTag(tagsinput, "input");
+      assert(!input.props.required);
+    });
+
     it("if beforeTagRemove return false, onTagRemove should not fire", function () {
       var tagsinput = createTagsInput({
         valueLink: null,


### PR DESCRIPTION
I have a hybrid React app which uses react-tagsinput. In some cases I wanted to be able to prevent form submission unless at least one tag is entered.