### PR TITLE
Add new property `maxTagLength` to limit the max length of the input

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,10 @@ is `true`.
 
 Add the `required` attribute to the input.
 
+##### maxTagLength
+
+Add the `maxLength` attribute to the input.
+
 ##### validate or validateAsync
 
 A function which returns true if a tag is valid, default function returns

--- a/react-tagsinput.js
+++ b/react-tagsinput.js
@@ -78,6 +78,7 @@
       , validateAsync: React.PropTypes.func
       , renderTag: React.PropTypes.func
       , required: React.PropTypes.bool
+      , maxTagLength: React.PropTypes.number
     }
 
     , getDefaultProps: function () {
@@ -341,6 +342,7 @@
           , onChange: this.onChange
           , onBlur: this.onBlur
           , required: needsTags
+          , maxLength: this.props.maxTagLength
         }))
       );
     }

--- a/test/index.js
+++ b/test/index.js
@@ -472,6 +472,17 @@ describe("TagsInput", function () {
       tagsinput.addTag("tag");
       assert.equal(tagsinput.getTags().length, 0);
     });
+
+    it("should add 'maxlength' attribute to input", function() {
+      var tagsinput = createTagsInput({
+        maxTagLength: 3
+      }).tagsInput();
+
+      var inputNode = React.findDOMNode(tagsinput.refs.input);
+
+      assert(inputNode.hasAttribute('maxlength'));
+      assert.equal(inputNode.getAttribute('maxlength'), 3);
+    })
   });
 
   describe("uncontrolled", function () {


### PR DESCRIPTION
Hey, I'm using your neat component in a project and I stumbled upon this while trying to limit the size of a tag before sending it to API.

It's a very small change, but I've wrote a test for it and updated the docs anyway.