### PR TITLE
Allow final layout to be customised

### DIFF
--- a/react-tagsinput.js
+++ b/react-tagsinput.js
@@ -52,6 +52,18 @@
     }
   });
 
+  function standardLayout(tagNodes, inputElement) {
+    var ns = this.props.classNamespace === "" ? "" : this.props.classNamespace + "-";
+    return (
+      React.createElement("div", {
+        style: this.props.style
+        , className: this.props.classNames.div || ns + "tagsinput"
+        , onClick: this.handleClick
+      }, tagNodes, inputElement
+      )
+    );
+  }
+
   var TagsInput = React.createClass({
     propTypes: {
       value: React.PropTypes.array
@@ -82,6 +94,7 @@
       , renderTag: React.PropTypes.func
       , required: React.PropTypes.bool
       , maxTagLength: React.PropTypes.number
+      , layout: React.PropTypes.func
     }
 
     , getDefaultProps: function () {
@@ -107,6 +120,7 @@
         , transform: function (tag) { return tag.trim(); }
         , renderTag: null
         , required: false
+        , layout: standardLayout
       };
     }
 
@@ -329,29 +343,25 @@
       var hasTags = tagNodes.length;
       var needsTags = this.props.required && !hasTags;
 
-      return (
-        React.createElement("div", {
-          style: this.props.style,
-          className: this.props.classNames.div || ns + "tagsinput"
-          , onClick: this.handleClick
-        }, tagNodes, React.createElement(Input, {
-          ref: "input"
-          , ns: ns
-          , name: this.props.name
-          , classNames: this.props.classNames
-          , placeholder: this.props.placeholder
-          , value: this.state.tag
-          , invalid: this.state.invalid
-          , validating: this.state.validating
-          , onKeyDown: this.onKeyDown
-          , onKeyUp: this.props.onKeyUp
-          , onChange: this.onChange
-          , onBlur: this.onBlur
-          , onFocus: this.props.onFocus
-          , required: needsTags
-          , maxLength: this.props.maxTagLength
-        }))
-      );
+      var inputElement = React.createElement(Input, {
+        ref: "input"
+        , ns: ns
+        , name: this.props.name
+        , classNames: this.props.classNames
+        , placeholder: this.props.placeholder
+        , value: this.state.tag
+        , invalid: this.state.invalid
+        , validating: this.state.validating
+        , onKeyDown: this.onKeyDown
+        , onKeyUp: this.props.onKeyUp
+        , onChange: this.onChange
+        , onBlur: this.onBlur
+        , onFocus: this.props.onFocus
+        , required: needsTags
+        , maxLength: this.props.maxTagLength
+      });
+
+      return this.props.layout.call(this, tagNodes, inputElement);
     }
   });
 


### PR DESCRIPTION
Hi,

This is a potential implementation for #47 if you consider supporting it. The idea is to allow the final layout of the input & tags to be customised as some changes are harder achieve with CSS than by changing the order of the tags.

My use case is wanting a larger input field and the tags listed below.

One note is that I've done this against the pre-react-0.14 code base as I'm not using react-0.14 quite yet. I think it should be easily rebased if you think it is worth including.

From the commit message:

> We move the final layout of the tags & input into a function provided by
the props with a default implementation.

> The default reproduces the current layout but the mechanism allows
client code to override the final layout so that, for example, the input
can appear above the tags instead of after them.

> We use function.call to pass the 'this' down to the layout function so
that it can access this.props and generally be an extension of the
render function.

An alternative approach would be to have a 'flip' prop which put the input first then the tags. It would be a more focussed change. This is a more general solution but might open things up too much. Not sure. Or perhaps I'm missing a trick completely and this isn't necessary.

Cheers,
Michael