### PR TITLE
Remove `--module-id ReactTagsInput` option in babel command in order …

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   },
   "scripts": {
     "test": "standard src/index.js && mocha --compilers js:babel/register",
-    "build": "babel --module-id ReactTagsInput -m umd src/index.js > react-tagsinput.js",
+    "build": "babel -m umd src/index.js > react-tagsinput.js",
     "coverage": "./node_modules/.bin/babel-node node_modules/.bin/isparta cover --report text --report html node_modules/.bin/_mocha -- --reporter dot",
     "prepublish": "npm run build"
   },

--- a/react-tagsinput.js
+++ b/react-tagsinput.js
@@ -1,6 +1,6 @@
 (function (global, factory) {
   if (typeof define === 'function' && define.amd) {
-    define('ReactTagsInput', ['exports', 'module', 'react'], factory);
+    define(['exports', 'module', 'react'], factory);
   } else if (typeof exports !== 'undefined' && typeof module !== 'undefined') {
     factory(exports, module, require('react'));
   } else {
@@ -8,7 +8,7 @@
       exports: {}
     };
     factory(mod.exports, mod, global.React);
-    global.ReactTagsInput = mod.exports;
+    global.index = mod.exports;
   }
 })(this, function (exports, module, _react) {
   'use strict';


### PR DESCRIPTION
…to generate an anonymous module