### PR TITLE
addOnBlur: add prop to add the content of input as tag when it loses focus

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -36,6 +36,7 @@ class TagsInput extends React.Component {
 
   static propTypes = {
     addKeys: React.PropTypes.array,
+    addOnBlur: React.PropTypes.bool,
     inputProps: React.PropTypes.object,
     onChange: React.PropTypes.func.isRequired,
     removeKeys: React.PropTypes.array,
@@ -120,6 +121,12 @@ class TagsInput extends React.Component {
     this.setState({tag})
   }
 
+  handleOnBlur (e) {
+    if (this.props.addOnBlur) {
+      this._addTag(e.target.value)
+    }
+  }
+
   handleRemove (tag) {
     this._removeTag(tag)
   }
@@ -142,6 +149,7 @@ class TagsInput extends React.Component {
       value: tag,
       onKeyDown: ::this.handleKeyDown,
       onChange: ::this.handleChange,
+      onBlur: ::this.handleOnBlur,
       ...this.inputProps()
     })
 

--- a/test/index.js
+++ b/test/index.js
@@ -55,6 +55,10 @@ function keyDown(comp, code) {
   TestUtils.Simulate.keyDown(comp.input(), {keyCode: code});
 }
 
+function blur(comp) {
+  TestUtils.Simulate.blur(comp.input());
+}
+
 function click(comp) {
   TestUtils.Simulate.click(comp);
 }
@@ -136,6 +140,37 @@ describe("TagsInput", () => {
       keyDown(comp, 44);
       assert.equal(comp.len(), 1, "there should be one tag");
       assert.equal(comp.tag(0), tag, "it should be the tag that was added");
+    });
+
+    it("should add a tag on blur, if `this.props.addOnBlur` is true", () => {
+      let comp = TestUtils.renderIntoDocument(<TestComponent addOnBlur={true} />);
+      let tag = randstring();
+
+      change(comp, tag);
+      blur(comp);
+
+      assert.equal(comp.len(), 1, "there should be one tag");
+      assert.equal(comp.tag(0), tag, "it should be the tag that was added");
+    });
+
+    it("should not add a tag on blur, if `this.props.addOnBlur` is false", () => {
+      let comp = TestUtils.renderIntoDocument(<TestComponent addOnBlur={false} />);
+      let tag = randstring();
+
+      change(comp, tag);
+      blur(comp);
+
+      assert.equal(comp.len(), 0, "there should be no tag");
+    });
+
+    it("should not add a tag on blur, if `this.props.addOnBlur` is not defined", () => {
+      let comp = TestUtils.renderIntoDocument(<TestComponent />);
+      let tag = randstring();
+
+      change(comp, tag);
+      blur(comp);
+
+      assert.equal(comp.len(), 0, "there should be no tag");
     });
 
     it("should remove a tag on key code 44", () => {


### PR DESCRIPTION
This PR adds the ability to create a new tag with the eventual content that is inside the input field when the input itself loses focus (blur).

Use case:
* user is tabbing through the fields of a form
* one of them is `react-tagsinput`
* user only puts one tag and tabs away
* user submits the form, and no tags has been saved 

Now, as soon as he "blurs" the input, a new tag will be added.

<hr /> 
On an unrelated note, these tests have no `assert`: https://github.com/olahol/react-tagsinput/blob/master/test/index.js#L206-L225, so their basically testing nothing except that no exception is thrown.  

Is that on purpose?