### PR TITLE
Use nicer × character for cross

### DIFF
--- a/react-tagsinput.css
+++ b/react-tagsinput.css
@@ -26,7 +26,7 @@
 }
 
 .react-tagsinput-tag a::before {
-  content: " x";
+  content: " ×";
 }
 
 .react-tagsinput-input {


### PR DESCRIPTION
Use bootstrap's `×` character for the cross in each tag, which IMO is nicer than an `x`. Will look like this:

<img width="736" alt="screen shot 2016-01-16 at 4 34 19 pm" src="https://cloud.githubusercontent.com/assets/1315101/12371484/da99c65c-bc6f-11e5-85b4-6c1ea1c6c1b9.png">
