### PR TITLE
Added regex validation in blur method

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -149,7 +149,8 @@ class TagsInput extends React.Component {
   }
 
   handleOnBlur (e) {
-    if (this.props.addOnBlur) {
+    let {validationRegex} = this.props
+    if (this.props.addOnBlur && validationRegex.test(e.target.value)) {
       this._addTag(e.target.value)
     }
   }


### PR DESCRIPTION
`handleOnBlur` method was missing regex validation so i have added it. I think it makes sense to have regex validation in this method as well since it add the tag.