### PR TITLE
do not prevent tab behavior when not adding a tag

### DIFF
--- a/react-tagsinput.js
+++ b/react-tagsinput.js
@@ -261,7 +261,10 @@
 
         if (tag !== '') {
           this._addTags([tag]);
+          return true;
         }
+
+        return false;
       }
     }, {
       key: 'handlePaste',
@@ -295,9 +298,8 @@
         var add = addKeys.indexOf(e.keyCode) !== -1;
         var remove = removeKeys.indexOf(e.keyCode) !== -1;
 
-        if (add) {
+        if (add && this.accept()) {
           e.preventDefault();
-          this.accept();
         }
 
         if (remove && value.length > 0 && empty) {

--- a/src/index.js
+++ b/src/index.js
@@ -161,7 +161,10 @@ class TagsInput extends React.Component {
     let {tag} = this.state
     if (tag !== '') {
       this._addTags([tag])
+      return true
     }
+
+    return false
   }
 
   handlePaste (e) {
@@ -186,9 +189,8 @@ class TagsInput extends React.Component {
     let add = addKeys.indexOf(e.keyCode) !== -1
     let remove = removeKeys.indexOf(e.keyCode) !== -1
 
-    if (add) {
+    if (add && this.accept()) {
       e.preventDefault()
-      this.accept()
     }
 
     if (remove && value.length > 0 && empty) {


### PR DESCRIPTION
Preventing the tab's behavior makes sense if it's actually triggering something else but shouldn't break keyboard navigation otherwise.

Note: given the current implementation of `addTags`, it can hardly return whether or not it actually added a tag. So there are still some cases where the tab key could be prevented erroneously. It'd be better to rely on `addTags`' return value to preventDefault.