### PR TITLE
pass addTag to renderInput

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,6 +229,8 @@ function defaultRenderInput (props) {
 }
 ```
 
+*Note: renderInput also receives `addTag` as a prop.*
+
 ##### renderLayout
 
 Renders the layout of the component. Takes `tagComponents` and `inputComponent` as args. Default is:

--- a/react-tagsinput.js
+++ b/react-tagsinput.js
@@ -161,7 +161,8 @@
 
   defaultRenderInput.propTypes = {
     value: _react2.default.PropTypes.string,
-    onChange: _react2.default.PropTypes.func
+    onChange: _react2.default.PropTypes.func,
+    addTag: _react2.default.PropTypes.func
   };
 
   function defaultRenderLayout(tagComponents, inputComponent) {
@@ -457,7 +458,8 @@
           onKeyDown: this.handleKeyDown.bind(this),
           onChange: this.handleChange.bind(this),
           onFocus: this.handleOnFocus.bind(this),
-          onBlur: this.handleOnBlur.bind(this)
+          onBlur: this.handleOnBlur.bind(this),
+          addTag: this.addTag.bind(this)
         }, this.inputProps()));
 
         return _react2.default.createElement(

--- a/src/index.js
+++ b/src/index.js
@@ -53,7 +53,8 @@ function defaultRenderInput (props) {
 
 defaultRenderInput.propTypes = {
   value: React.PropTypes.string,
-  onChange: React.PropTypes.func
+  onChange: React.PropTypes.func,
+  addTag: React.PropTypes.func
 }
 
 function defaultRenderLayout (tagComponents, inputComponent) {
@@ -315,6 +316,7 @@ class TagsInput extends React.Component {
       onChange: ::this.handleChange,
       onFocus: ::this.handleOnFocus,
       onBlur: ::this.handleOnBlur,
+      addTag: ::this.addTag,
       ...this.inputProps()
     })
 


### PR DESCRIPTION
For an autocomplete to work with react-tagsinput, it has to have a way to add a tag when selecting a suggestion (via pressing the enter key or clicking on an entry).