### PR TITLE
add tagDisplayProp option

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,16 +200,20 @@ Props passed down to every tag component. Defualt is: `{className: 'react-tagsin
 
 Props passed down to input. Default is: `{className: 'react-tagsinput-input'}`
 
+##### tagDisplayProp
+
+The tags' property to be used when displaying/adding one. Default is: `null` which causes the tags to be an array of strings.
+
 ##### renderTag
 
 Render function for every tag. Default is:
 
 ```javascript
 function defaultRenderTag (props) {
-  let {tag, key, onRemove, ...other} = props
+  let {tag, key, onRemove, getTagDisplayValue, ...other} = props
   return (
     <span key={key} {...other}>
-      {tag}
+      {getTagDisplayValue(tag)}
       <a onClick={(e) => onRemove(key)} />
     </span>
   )

--- a/test/index.js
+++ b/test/index.js
@@ -423,6 +423,14 @@ describe("TagsInput", () => {
       assert.equal(comp.len(), tags.length, "there should be one tag");
     });
 
+    it("should use tagDisplayProp to deal with objects", () => {
+      let comp = TestUtils.renderIntoDocument(<TestComponent tagDisplayProp={'name'} />);
+
+      add(comp, 'foo');
+      assert.equal(comp.len(), 1, "there should be one tag");
+      assert.deepEqual(comp.tag(0), {name:'foo'}, "should be {name: 'foo'}");
+    });
+
     it("should render input with renderInput", () => {
       let renderInput = (props) => {
         return <input key={props.key} className="test" />;


### PR DESCRIPTION
This PR adds a way to have tags not being just a string but an object. Once again, it's especially useful when you have an autocomplete that suggests tags with an id and other properties.