### PR TITLE
Fix current value prop

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Highly customizable [React](http://facebook.github.io/react/index.html) componen
         * [value (required)](#value-required)
         * [onChange (required)](#onchange-required)
         * [addKeys](#addkeys)
-        * [currentValue](#currentValue)
+        * [currentValue](#currentvalue)
         * [onlyUnique](#onlyunique)
         * [validationRegex](#validationregex)
         * [disabled](#disabled)

--- a/src/index.js
+++ b/src/index.js
@@ -331,6 +331,10 @@ class TagsInput extends React.Component {
   }
 
   componentWillReceiveProps (nextProps) {
+    if (!nextProps.currentValue) {
+      return
+    }
+
     this.setState({
       tag: nextProps.currentValue
     })

--- a/test/index.js
+++ b/test/index.js
@@ -520,6 +520,49 @@ describe("TagsInput", () => {
       comp.tagsinput().addTag("test");
       assert.equal(comp.len(), 1, "there should be one tag")
     });
+
+    describe("componentWillReceiveProps", () => {
+      it("updates the state", () => {
+        const TestParent = React.createFactory(React.createClass({
+          getInitialState() {
+            return {
+              currentValue: "init"
+            };
+          },
+          render() {
+            return <TestComponent ref="testComp" currentValue={this.state.currentValue} />
+          }
+        }));
+
+        let parent = TestUtils.renderIntoDocument(TestParent());
+        parent.setState({
+          currentValue: "test"
+        });
+
+        assert.equal(parent.refs.testComp.props.currentValue, "test", "sets the correct value for currentValue")
+      })
+
+      it("does not modify the state", () => {
+        const TestParent = React.createFactory(React.createClass({
+          getInitialState() {
+            return {
+              currentValue: "init",
+              fake: "fake"
+            };
+          },
+          render() {
+            return <TestComponent ref="testComp" fake={this.state.fake} currentValue={this.state.currentValue} />
+          }
+        }));
+
+        let parent = TestUtils.renderIntoDocument(TestParent());
+        parent.setState({
+          fake: "test"
+        });
+
+        assert.equal(parent.refs.testComp.props.currentValue, "init", "does not modify currentValue")
+      })
+    });
   });
 
   describe("coverage", () => {


### PR DESCRIPTION
Hi @olahol,

In #94 I added a new property `currentValue` but apparently I also introduced a small bug with this.

When `componentWillReceiveProps` was called but the `currentValue` wasn't set it will set the internal state of `tag` to undefined, which shouldn't be the expected behavior.
I added a condition in `componentWillReceiveProps` to prevent this from happening by making an early return. I also added tests to make sure this behavior is covered.

Thanks again for react-tagsinput!