### PR TITLE
avoid add tag when event is prevented (Compatibility with react-autosuggest)

### DIFF
--- a/react-tagsinput.js
+++ b/react-tagsinput.js
@@ -363,6 +363,9 @@
     }, {
       key: 'handleKeyDown',
       value: function handleKeyDown(e) {
+        if (e.defaultPrevented) {
+          return;
+        }
         var _props3 = this.props;
         var value = _props3.value;
         var removeKeys = _props3.removeKeys;
@@ -473,6 +476,10 @@
     }, {
       key: 'componentWillReceiveProps',
       value: function componentWillReceiveProps(nextProps) {
+        if (!nextProps.currentValue) {
+          return;
+        }
+
         this.setState({
           tag: nextProps.currentValue
         });

--- a/src/index.js
+++ b/src/index.js
@@ -237,6 +237,9 @@ class TagsInput extends React.Component {
   }
 
   handleKeyDown (e) {
+    if (e.defaultPrevented) {
+      return
+    }
     let {value, removeKeys, addKeys} = this.props
     let {tag} = this.state
     let empty = tag === ''


### PR DESCRIPTION
as pointed out in https://github.com/olahol/react-tagsinput/issues/100

> Using the autocomplete example on example/index.html, if you type the first few letters of a state and then use the down arrow key to choose the state and press Enter to select it, the actual tag created is not the suggestion, but the letters typed so far. Selecting the state suggestion with the mouse works as expected.

Using this code in addition to this pull request solve the problem.

```
let handleOnChange = (event, {newValue, method}) => {
        if(method === 'enter') {
          event.preventDefault()
        } else {
          props.onChange(event)
        }
      }

return (
        <Autosuggest
          inputProps={{...other, onChange: handleOnChange}}
          otherFields...
        />
      )
```