### PR TITLE
Returned back ability to add non-string entities as tags

### DIFF
--- a/react-tagsinput.js
+++ b/react-tagsinput.js
@@ -281,7 +281,12 @@
           return validationRegex.test(_this2._getTagDisplayValue(tag));
         });
         tags = tags.filter(function (tag) {
-          return _this2._getTagDisplayValue(tag).trim().length > 0;
+          var tagDisplayValue = _this2._getTagDisplayValue(tag);
+          if (typeof tagDisplayValue.trim === 'function') {
+            return tagDisplayValue.trim().length > 0;
+          } else {
+            return tagDisplayValue;
+          }
         });
 
         if (maxTags >= 0) {

--- a/src/index.js
+++ b/src/index.js
@@ -171,7 +171,14 @@ class TagsInput extends React.Component {
     }
 
     tags = tags.filter(tag => validationRegex.test(this._getTagDisplayValue(tag)))
-    tags = tags.filter(tag => this._getTagDisplayValue(tag).trim().length > 0)
+    tags = tags.filter(tag => {
+      let tagDisplayValue = this._getTagDisplayValue(tag)
+      if (typeof tagDisplayValue.trim === 'function') {
+        return tagDisplayValue.trim().length > 0
+      } else {
+        return tagDisplayValue
+      }
+    })
 
     if (maxTags >= 0) {
       let remainingLimit = Math.max(maxTags - value.length, 0)


### PR DESCRIPTION
Hi, in my setup I am passing objects as tags, and using their properties in renderTag function, and was disappointed that in newer version passing objects wasn't working anymore. Have made a fix for that!

Thank you, Alex