### PR TITLE
Add onValidationReject callback

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ Highly customizable [React](http://facebook.github.io/react/index.html) componen
         * [inputValue](#inputvalue)
         * [onlyUnique](#onlyunique)
         * [validationRegex](#validationregex)
+        * [onValidationReject](#onvalidationreject)
         * [disabled](#disabled)
         * [maxTags](#maxtags)
         * [addOnBlur](#addonblur)
@@ -199,6 +200,10 @@ Allow only unique tags, default is `false`.
 ##### validationRegex
 
 Allow only tags that pass this regex to be added. Default is `/.*/`.
+
+##### onValidationReject
+
+Callback when tags are rejected through validationRegex, passing array of tags as the argument.
 
 ##### disabled
 

--- a/src/index.js
+++ b/src/index.js
@@ -176,13 +176,14 @@ class TagsInput extends React.Component {
   }
 
   _addTags (tags) {
-    let {validationRegex, onChange, onlyUnique, maxTags, value} = this.props
+    let {validationRegex, onChange, onValidationReject, onlyUnique, maxTags, rejectedTags, value} = this.props
 
     if (onlyUnique) {
       tags = uniq(tags)
       tags = tags.filter(tag => value.every(currentTag => this._getTagDisplayValue(currentTag) !== this._getTagDisplayValue(tag)))
     }
 
+    rejectedTags = tags.filter(tag => !validationRegex.test(this._getTagDisplayValue(tag)))
     tags = tags.filter(tag => validationRegex.test(this._getTagDisplayValue(tag)))
     tags = tags.filter(tag => {
       let tagDisplayValue = this._getTagDisplayValue(tag)
@@ -196,6 +197,10 @@ class TagsInput extends React.Component {
     if (maxTags >= 0) {
       let remainingLimit = Math.max(maxTags - value.length, 0)
       tags = tags.slice(0, remainingLimit)
+    }
+
+    if (onValidationReject && rejectedTags.length > 0) {
+      onValidationReject(rejectedTags)
     }
 
     if (tags.length > 0) {

--- a/src/index.js
+++ b/src/index.js
@@ -176,14 +176,14 @@ class TagsInput extends React.Component {
   }
 
   _addTags (tags) {
-    let {validationRegex, onChange, onValidationReject, onlyUnique, maxTags, rejectedTags, value} = this.props
+    let {validationRegex, onChange, onValidationReject, onlyUnique, maxTags, value} = this.props
 
     if (onlyUnique) {
       tags = uniq(tags)
       tags = tags.filter(tag => value.every(currentTag => this._getTagDisplayValue(currentTag) !== this._getTagDisplayValue(tag)))
     }
 
-    rejectedTags = tags.filter(tag => !validationRegex.test(this._getTagDisplayValue(tag)))
+    const rejectedTags = tags.filter(tag => !validationRegex.test(this._getTagDisplayValue(tag)))
     tags = tags.filter(tag => validationRegex.test(this._getTagDisplayValue(tag)))
     tags = tags.filter(tag => {
       let tagDisplayValue = this._getTagDisplayValue(tag)

--- a/test/index.js
+++ b/test/index.js
@@ -195,13 +195,22 @@ describe("TagsInput", () => {
     });
 
     it("should support validation", () => {
-      let comp = TestUtils.renderIntoDocument(<TestComponent addOnPaste={true} validationRegex={/a+/} />);
       let firstTag = 'aaa';
       let secondTag = randstring();
+      let thirdTag = randstring();
 
-      paste(comp, firstTag + ' ' + secondTag);
+      let fireCount = 0;
+      let onValidationReject = function (tags) {
+        assert.deepEqual(tags, [secondTag, thirdTag], "there should be rejected tags in onValidationReject callback");
+        fireCount += 1
+      }
+
+      let comp = TestUtils.renderIntoDocument(<TestComponent addOnPaste={true} onValidationReject={onValidationReject} validationRegex={/a+/} />);
+
+      paste(comp, firstTag + ' ' + secondTag + ' ' + thirdTag);
       assert.equal(comp.len(), 1, "there should be one tag");
       assert.equal(comp.tag(0), firstTag, "it should be the tag that was added");
+      assert.equal(fireCount, 1, "onValidationReject should be fired once");
     });
 
     it("should respect limit", () => {
@@ -457,6 +466,18 @@ describe("TagsInput", () => {
       add(comp, 'a');
       assert.equal(comp.len(), 1, "there should be one tag");
     });
+
+    it("should fire onValidationReject when tag is rejected through validation", () => {
+      let fireCount = 0;
+      let onValidationReject = function (tags) {
+        assert.deepEqual(tags, ['b']);
+        fireCount += 1
+      }
+      let comp = TestUtils.renderIntoDocument(<TestComponent validationRegex={/a+/} onValidationReject={onValidationReject} />);
+      add(comp, 'b');
+      add(comp, 'a');
+      assert.equal(fireCount, 1)
+    })
 
     it("should add pass changed value to onChange", () => {
       let onChange = function (tags, changed, changedIndexes) {


### PR DESCRIPTION
I want to provide some feedback to user when his tags are rejected, it's pretty confusing when tags are just disappearing.

Added a callback `onValidationReject` when tags are rejected through `validationRegex`