### PR TITLE
Set global name separately from module id, fix #53

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -3,6 +3,13 @@
   "plugins": [
     "add-module-exports",
     "transform-react-remove-prop-types",
-    ["transform-es2015-modules-umd", {"globals": {"react": "React"}}]
+    ["transform-es2015-modules-umd", {
+      "globals": {
+        "react": "React",
+        "prop-types": "PropTypes",
+        "index": "ReactTagsInput"
+      },
+      "exactGlobals": true
+    }]
   ]
 }

--- a/example/requirejs/app.js
+++ b/example/requirejs/app.js
@@ -1,0 +1,10 @@
+requirejs.config({
+  paths: {
+    'react': 'https://unpkg.com/react@16.3.1/umd/react.development',
+    'react-dom': 'https://unpkg.com/react-dom@16.3.1/umd/react-dom.development',
+    'prop-types': 'https://unpkg.com/prop-types@15.6.1/prop-types',
+    'react-tagsinput': '../../react-tagsinput',
+  },
+});
+
+requirejs(['main']);

--- a/example/requirejs/index.html
+++ b/example/requirejs/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>requirejs examples</title>
+	<link rel="stylesheet" href="../../react-tagsinput.css">
+</head>
+<body>
+  <div id="react-app"></div>
+  <script data-main="app.js" src="https://unpkg.com/requirejs@2.3.5/require.js"></script>
+</body>
+</html>

--- a/example/requirejs/main.js
+++ b/example/requirejs/main.js
@@ -1,0 +1,26 @@
+define(['react', 'react-dom', 'react-tagsinput'], (React, ReactDOM, ReactTagsInput) => {
+  class SimpleTagsInput extends React.Component {
+    constructor(props) {
+      super(props);
+
+      this.state = { tags: [] };
+
+      this.handleChange = this.handleChange.bind(this);
+    }
+
+    handleChange(tags) {
+      this.setState({ tags });
+    }
+
+    render() {
+      return (
+        React.createElement(ReactTagsInput, {
+          value: this.state.tags,
+          onChange: this.handleChange,
+        })
+      );
+    }
+  }
+
+  ReactDOM.render(React.createElement(SimpleTagsInput), document.getElementById('react-app'));
+});

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   },
   "scripts": {
     "test": "standard src/index.js && mocha --compilers js:babel-register",
-    "build": "babel --module-id ReactTagsInput -m umd src/index.js > react-tagsinput.js",
+    "build": "babel src/index.js > react-tagsinput.js",
     "build-example": "reactpack --no-extract --no-source-map --no-html example/index.js example/",
     "build-example-watch": "reactpack -w --no-extract --no-source-map --no-html example/index.js example/",
     "coverage": "istanbul cover --report text --report html _mocha -- --compilers js:babel-register",

--- a/react-tagsinput.js
+++ b/react-tagsinput.js
@@ -1,13 +1,13 @@
 (function (global, factory) {
   if (typeof define === "function" && define.amd) {
-    define('ReactTagsInput', ['module', 'exports', 'react', 'prop-types'], factory);
+    define(['module', 'exports', 'react', 'prop-types'], factory);
   } else if (typeof exports !== "undefined") {
     factory(module, exports, require('react'), require('prop-types'));
   } else {
     var mod = {
       exports: {}
     };
-    factory(mod, mod.exports, global.React, global.propTypes);
+    factory(mod, mod.exports, global.React, global.PropTypes);
     global.ReactTagsInput = mod.exports;
   }
 })(this, function (module, exports, _react, _propTypes) {


### PR DESCRIPTION
- We can use the `transform-es2015-modules-umd` plugin to set the global name without using module id
- I tested the umd build by creating a requirejs-based example (see `examples/requirejs/index.html`)
- I didn't transpile the requirejs example because (1) I wanted to simplify the requirejs example, and (2) it only needs to run on dev machines (which normally have the latest version of a browser, and don't need transpiling).