### PR TITLE
🐛add missing accept binding

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -84,6 +84,7 @@ class TagsInput extends React.Component {
     this.state = {tag: '', isFocused: false}
     this.focus = ::this.focus
     this.blur = ::this.blur
+    this.accept = ::this.accept
   }
 
   static propTypes = {


### PR DESCRIPTION
### Description
- The `accept` function was not bound to the class, making it not possible to call it (throws `accept` is not a function).

### Actions
- Bind `accept` function to class.