### PR TITLE
Fix input focus issue when it is multi-line

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -330,7 +330,10 @@ class TagsInput extends React.Component {
   }
 
   handleClick (e) {
-    if (e.target === this.div) {
+    const clickedElement = e.target
+    const parentElement = e.target && e.target.parentElement
+
+    if (clickedElement === this.div || parentElement === this.div) {
       this.focus()
     }
   }

--- a/test/index.js
+++ b/test/index.js
@@ -141,6 +141,13 @@ describe("TagsInput", () => {
     it("should focus on input when clicking on component div", () => {
       let comp = TestUtils.renderIntoDocument(<TestComponent />);
       click(comp.tagsinput().div);
+      assert.equal(comp.tagsinput().div.className.includes("react-tagsinput--focused"), true);
+    });
+
+    it("should focus on input when clicking on component's child span (which is triggered when input is multi-line)", () => {
+      let comp = TestUtils.renderIntoDocument(<TestComponent />);
+      click(comp.tagsinput().div.firstChild);
+      assert.equal(comp.tagsinput().div.className.includes("react-tagsinput--focused"), true);
     });
 
     it("should not add empty tag", () => {


### PR DESCRIPTION
When multiple tags cause "tags-input" to become multi-line, inner wrapper span element becomes click event's target element. For that reason, focus event handler's invocation check returns false (index.js, line: 333) and "tags-input" element's focus gets lost if user clicks first line or outside of "inner input" element. To fix that issue, span element's being clicked (index.js, line: 64) became a valid invocation check for focus.