### PR TITLE
Updated `keyCode` to `code` in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,7 +237,7 @@ Callback from the input box, gets one argument `value` which is the content of t
 
 ##### addKeys
 
-An array of key codes that add a tag, default is `[9, 13]` (Tab and Enter).
+An array of key codes that add a tag, default is `['Enter', 'Tab']`.
 
 ##### currentValue
 


### PR DESCRIPTION
[keyCode](https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/keyCode) is deprecated.  
I know that you accept both `code` and `keyCode`, but maybe it's better to show in docs usage with [code](https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/code) only ?