### PR TITLE
Docs: `addKeys`: add note about support for key strings

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,7 +237,7 @@ Callback from the input box, gets one argument `value` which is the content of t
 
 ##### addKeys
 
-An array of key codes that add a tag, default is `[9, 13]` (Tab and Enter).
+An array of [keys](https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/key) or [key codes](https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/which) that add a tag, default is `[9, 13]` (Tab and Enter).
 
 ##### currentValue
 


### PR DESCRIPTION
Support was added in https://github.com/olahol/react-tagsinput/pull/156