### PR TITLE
#213: Fixed empty tag added on blur

### DIFF
--- a/react-tagsinput.js
+++ b/react-tagsinput.js
@@ -496,7 +496,7 @@
           onBlur(e);
         }
 
-        if (this.props.addOnBlur) {
+        if (this.props.addOnBlur && e.target.value) {
           var tag = this._makeTag(e.target.value);
           this._addTags([tag]);
         }

--- a/src/index.js
+++ b/src/index.js
@@ -377,7 +377,7 @@ class TagsInput extends React.Component {
       onBlur(e)
     }
 
-    if (this.props.addOnBlur) {
+    if (this.props.addOnBlur && e.target.value) {
       const tag = this._makeTag(e.target.value)
       this._addTags([tag])
     }


### PR DESCRIPTION
Hello,

Thanks for the library!

Fixed [#213](https://github.com/olahol/react-tagsinput/issues/213). I was able to reproduce this issue when the field is focused and clicked outside the input. Please review this PR and let me know your comments.